### PR TITLE
Add missing release notes since 8th of April

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -1,3 +1,36 @@
+# Release 21st of May 2024
+
+- Add functionality to bin price charts on the DEX into time windows such as 1h, 4h, 1d etc
+- Improve error messages shown in the Staking platform
+
+# Release 13th of May 2024
+
+- Significant Staking platform refactoring and performance improvements. Loading staking vaults is now more than twice as fast.
+
+# Release 7th of May 2024
+
+- Add $NVL token
+- Update $MILK token to use the correct muesli icon
+
+# Release 6th of May 2024
+
+- Add reward distribution differentiation between Accelerated Yield and Vault Staking rewards
+- Staking V2 goes live with changes including GENS flex staking as well as Rewards Multiplying revenue sharing staking vaults
+
+# Release 1st of May 2024
+
+- Staking V2 maintenance
+- Staking V2 UI changes
+
+# Release 22nd of April 2024
+
+- Candlestick option is added to the DEX price chart
+- Add support for multiple Plutus smart contract scripts
+
+# Release 9th of April 2024
+
+- Add $SPX token to the list of available tokens to trade.
+
 # Release 8th of April 2024
 
 - Improved the "To" and "From" asset selector dropdown visually and functionally.
@@ -17,7 +50,7 @@
 
 ## What's New
 
-- USDM token has been added to the list of available tokens to trade.
+- $USDM token has been added to the list of available tokens to trade.
 
 # Release 15th of March 2024
 

--- a/releases.md
+++ b/releases.md
@@ -9,7 +9,7 @@
 
 # Release 7th of May 2024
 
-- Add $NVL token
+- Add $NVL token to the list of available tokens to trade.
 - Update $MILK token to use the correct muesli icon
 
 # Release 6th of May 2024
@@ -24,7 +24,7 @@
 
 # Release 22nd of April 2024
 
-- Candlestick option is added to the DEX price chart
+- Candlestick chart support added to the DEX DApp
 - Add support for multiple Plutus smart contract scripts
 
 # Release 9th of April 2024

--- a/releases.md
+++ b/releases.md
@@ -1,7 +1,7 @@
 # Release 21st of May 2024
 
-- Add functionality to bin price charts on the DEX into time windows such as 1h, 4h, 1d etc
-- Improve error messages shown in the Staking platform
+- Add functionality to bin price charts on the DEX into time windows such as 1h, 4h, 1d etc.
+- Improve error messages shown in the Staking platform.
 
 # Release 13th of May 2024
 
@@ -10,22 +10,22 @@
 # Release 7th of May 2024
 
 - Add $NVL token to the list of available tokens to trade.
-- Update $MILK token to use the correct muesli icon
+- Update $MILK token to use the correct muesli icon.
 
 # Release 6th of May 2024
 
-- Add reward distribution differentiation between Accelerated Yield and Vault Staking rewards
-- Staking V2 goes live with changes including GENS flex staking as well as Rewards Multiplying revenue sharing staking vaults
+- Add reward distribution differentiation between Accelerated Yield and Vault Staking rewards.
+- Staking V2 goes live with changes including GENS flex staking as well as Rewards Multiplying revenue sharing staking vaults.
 
 # Release 1st of May 2024
 
-- Staking V2 maintenance
-- Staking V2 UI changes
+- Staking V2 maintenance.
+- Staking V2 UI changes.
 
 # Release 22nd of April 2024
 
-- Candlestick chart support added to the DEX DApp
-- Add support for multiple Plutus smart contract scripts
+- Candlestick chart support added to the DEX DApp.
+- Add support for multiple Plutus smart contract scripts.
 
 # Release 9th of April 2024
 

--- a/releases.md
+++ b/releases.md
@@ -25,7 +25,6 @@
 # Release 22nd of April 2024
 
 - Candlestick chart support added to the DEX DApp.
-- Add support for multiple Plutus smart contract scripts.
 
 # Release 9th of April 2024
 


### PR DESCRIPTION
Not perfect but should cover the important releases missed. I sorted merges by `base:mainnet ` in GitHub and looked at all merges since the last release note on the 8th of April